### PR TITLE
Filled README + changed display of alerts to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,28 @@ Make sure to install the [`cordova-plugin-inappbrowser` plugin](https://github.c
 
 ## Usage
 
-Example usage would be to put this in your controller:
+First you need to configure oauth1Client with your API data:
+
+    angular.module('myModule', [
+        'oauth1Client'
+    ])
+
+    .config(function(oauth1ClientProvider) {
+        oauth1ClientProvider.config({
+            consumerKey: '',
+            consumerSecret: '',
+            requestEndpoint: '',
+            authorizeEndpoint: '',
+            accessEndpoint: '',
+            oauthCallback: ''
+        });
+    })
+
+Then authorize your app in your controller:
 
     var authorizationProcess = oauth1Client.authorize();
+
+Finally do some requests to server:
 
     authorizationProcess.then(function(authorizedHttp) {
         authorizedHttp({

--- a/dist/angular-oauth1-client.js
+++ b/dist/angular-oauth1-client.js
@@ -280,6 +280,7 @@ angular.module('oauth1Client', ['LocalStorageModule'])
                 });
             })
             .error(function(data, status, headers, config) {
+                alert("Error: " + JSON.stringify(data));
                 deferred.reject("Error: " + data);
             });
             return deferred.promise;

--- a/dist/angular-oauth1-client.js
+++ b/dist/angular-oauth1-client.js
@@ -328,7 +328,7 @@ angular.module('oauth1Client', ['LocalStorageModule'])
                 });
             })
             .error(function(data, status, headers, config) {
-                alert("Error: " + data);
+                alert("Error: " + JSON.stringify(data));
             });
             return deffered.promise;
         }

--- a/src/angular-oauth1-client.js
+++ b/src/angular-oauth1-client.js
@@ -278,6 +278,7 @@ angular.module('oauth1Client', ['LocalStorageModule'])
                 });
             })
             .error(function(data, status, headers, config) {
+                alert("Error: " + JSON.stringify(data));
                 deferred.reject("Error: " + data);
             });
             return deferred.promise;

--- a/src/angular-oauth1-client.js
+++ b/src/angular-oauth1-client.js
@@ -326,7 +326,7 @@ angular.module('oauth1Client', ['LocalStorageModule'])
                 });
             })
             .error(function(data, status, headers, config) {
-                alert("Error: " + data);
+                alert("Error: " + JSON.stringify(data));
             });
             return deffered.promise;
         }


### PR DESCRIPTION
More info in usage part of README + alerts are now possible to be read by human -> http sends json object which was displayed as: "Error: [Object object]" until now.
